### PR TITLE
Make cmlib a private dependency; add mlton support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: sml
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y --force-yes mlton
+install:
+  - git submodule init
+  - git submodule update --init --recursive
+script:
+  - mlton telescopes.mlb

--- a/development.cm
+++ b/development.cm
@@ -1,7 +1,0 @@
-Library
-  signature TELESCOPE
-  signature LABEL
-  functor Telescope
-  functor TelescopeNotation
-is
-  telescopes.cm (bind:(anchor:libs value:lib))

--- a/lib/cmlib.cm
+++ b/lib/cmlib.cm
@@ -1,0 +1,7 @@
+Library
+  signature DICT
+  signature ORDERED
+  functor SplayDict
+  structure StringListDict
+is
+  cmlib/cmlib.cm

--- a/lib/cmlib.mlb
+++ b/lib/cmlib.mlb
@@ -1,0 +1,8 @@
+local
+  cmlib/cmlib.mlb
+in
+  signature DICT
+  signature ORDERED
+  functor SplayDict
+  structure StringListDict
+end

--- a/src/telescope.fun
+++ b/src/telescope.fun
@@ -14,7 +14,7 @@ struct
     ) d2 d1
 end
 
-functor Telescope (L : LABEL) :> TELESCOPE where Label = L =
+functor Telescope (L : LABEL) :> TELESCOPE where type Label.t = L.t =
 struct
   type label = L.t
   structure Label = L
@@ -242,7 +242,7 @@ struct
           | go (Cons (lbl, a, tele')) r =
               go (out tele') (r ^ ", " ^ L.toString lbl ^ " : " ^ pretty a)
       in
-        go (out tele) "·"
+        go (out tele) "\194\183"
       end
   end
 

--- a/telescopes.cm
+++ b/telescopes.cm
@@ -4,6 +4,6 @@ Library
   functor Telescope
   functor TelescopeNotation
 is
-  $libs/cmlib/cmlib.cm
+  lib/cmlib.cm
   src/telescope.sig
   src/telescope.fun

--- a/telescopes.cm
+++ b/telescopes.cm
@@ -4,6 +4,7 @@ Library
   functor Telescope
   functor TelescopeNotation
 is
+  $/basis.cm
   lib/cmlib.cm
   src/telescope.sig
   src/telescope.fun

--- a/telescopes.mlb
+++ b/telescopes.mlb
@@ -1,0 +1,11 @@
+local
+  $(SML_LIB)/basis/basis.mlb
+  lib/cmlib.mlb
+  src/telescope.sig
+  src/telescope.fun
+in
+  signature TELESCOPE
+  signature LABEL
+  functor Telescope
+  functor TelescopeNotation
+end


### PR DESCRIPTION
We don't export anything from cmlib, so we can manage the dependency locally.
