### PR TITLE
Add new Duplicate exception

### DIFF
--- a/src/telescope.fun
+++ b/src/telescope.fun
@@ -6,6 +6,7 @@ struct
   type label = L.t
 
   exception Absent
+  exception Duplicate of label
 
   structure Internal =
   struct
@@ -19,19 +20,19 @@ struct
 
     fun snoc (list, dict) lbl x =
       if D.member dict lbl then
-        raise Fail ("snoc: duplicates " ^ L.toString lbl)
+        raise Duplicate lbl
       else
         (lbl :: list, D.insert dict lbl x)
 
     fun cons lbl x (list, dict) =
       if D.member dict lbl then
-        raise Fail ("cons: duplicates " ^ L.toString lbl)
+        raise Duplicate lbl
       else
         (list @ [lbl], D.insert dict lbl x)
 
     fun append (list1, dict1) (list2, dict2) =
       let
-        val dict = D.union dict1 dict2 (fn (l, _, _) => raise Fail ("append: duplicates " ^ L.toString l))
+        val dict = D.union dict1 dict2 (fn (l, _, _) => raise Duplicate l)
       in
         (list2 @ list1, dict)
       end
@@ -88,7 +89,7 @@ struct
 
     fun splice (list, dict) x (listx, dictx) =
       let
-        val dict' = D.union (D.remove dict x) dictx (fn (l, _, _) => raise Fail ("splice: duplicates " ^ L.toString l))
+        val dict' = D.union (D.remove dict x) dictx (fn (l, _, _) => raise Duplicate l)
         val (xs, ys) = splitList x list
       in
         (List.rev xs @ listx @ ys, dict')

--- a/src/telescope.sig
+++ b/src/telescope.sig
@@ -40,6 +40,8 @@ sig
 
   val isEmpty : 'a telescope -> bool
 
+  exception Duplicate of label
+
   (* smart constructors *)
   val empty : 'a telescope
   val snoc : 'a telescope -> label -> 'a -> 'a telescope


### PR DESCRIPTION
The telescope library previously threw `Fail` when it detected that a duplicate name was about to be used. 

In RedPRL, such an error can be easily triggered by a hapless user, so the error should be handled in a nice way, but it's not appropriate to catch `Fail`. 

This PR introduces a separate exception for this case. There will be a companion PR to RedPRL.